### PR TITLE
add feature: Session limit (+ a few smaller tweaks)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shuffle-bird",
-  "version": "1.1.0",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "shuffle-bird",
-      "version": "1.1.0",
+      "version": "1.2.2",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@emotion/react": "^11.10.5",

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -1,0 +1,43 @@
+import { Button, ButtonGroup as MuiButtonGroup } from "@mui/material";
+
+type Props<T> = {
+  choices: Array<T>;
+  selected: T;
+  onSelect: (selected: T) => void;
+};
+
+type NamedValue<T> = {
+  name: string;
+  value: T;
+};
+
+function isNamedValue<T>(value: any): value is NamedValue<T> {
+  return value && typeof value.name === "string" && value.value !== undefined;
+}
+
+export const AutoButtonGroup = <T extends (number | string) | NamedValue<T>>({
+  choices,
+  selected,
+  onSelect,
+}: Props<T>) => (
+  <MuiButtonGroup
+    variant="contained"
+    aria-label="outlined primary button group"
+  >
+    {choices.map((value) => {
+      const _value = isNamedValue(value) ? value.value : value;
+      const name = isNamedValue(value) ? value.name : value;
+      return (
+        <Button
+          key={_value.toString()}
+          color={selected === _value ? "info" : undefined}
+          onClick={() => {
+            onSelect(_value);
+          }}
+        >
+          {name.toString()}
+        </Button>
+      );
+    })}
+  </MuiButtonGroup>
+);

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -5,17 +5,11 @@ type NamedValue<T> = {
   value: T;
 };
 
-type Choice<T> = T | NamedValue<T>;
-
 type Props<T extends number | string> = {
-  choices: Array<Choice<T>>;
+  choices: Array<NamedValue<T>>;
   selected: T;
   onSelect: (selected: T) => void;
 };
-
-function isNamedValue<T>(value: any): value is NamedValue<T> {
-  return value && typeof value.name === "string" && value.value !== undefined;
-}
 
 export const AutoButtonGroup = <T extends number | string>({
   choices,
@@ -26,19 +20,19 @@ export const AutoButtonGroup = <T extends number | string>({
     variant="contained"
     aria-label="outlined primary button group"
   >
-    {choices.map((value) => {
-      const resolvedValue = isNamedValue(value) ? value.value : value;
-      const name = isNamedValue(value) ? value.name : value;
+    {choices.map((namedValue) => {
+      const value = namedValue.value;
+      const name = namedValue.name;
       return (
         <Button
-          key={resolvedValue.toString()}
-          color={selected === resolvedValue ? "info" : undefined}
+          key={value}
+          color={selected === value ? "info" : undefined}
           onClick={() => {
-            onSelect(resolvedValue);
+            onSelect(value);
           }}
           sx={{ textTransform: "none" }}
         >
-          {name.toString()}
+          {name}
         </Button>
       );
     })}

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -27,14 +27,14 @@ export const AutoButtonGroup = <T extends number | string>({
     aria-label="outlined primary button group"
   >
     {choices.map((value) => {
-      const _value = isNamedValue(value) ? value.value : value;
+      const resolvedValue = isNamedValue(value) ? value.value : value;
       const name = isNamedValue(value) ? value.name : value;
       return (
         <Button
-          key={_value.toString()}
-          color={selected === _value ? "info" : undefined}
+          key={resolvedValue.toString()}
+          color={selected === resolvedValue ? "info" : undefined}
           onClick={() => {
-            onSelect(_value);
+            onSelect(resolvedValue);
           }}
           sx={{ textTransform: "none" }}
         >

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -1,21 +1,23 @@
 import { Button, ButtonGroup as MuiButtonGroup } from "@mui/material";
 
-type Props<T> = {
-  choices: Array<T>;
-  selected: T;
-  onSelect: (selected: T) => void;
-};
-
 type NamedValue<T> = {
   name: string;
   value: T;
+};
+
+type Choice<T> = T | NamedValue<T>;
+
+type Props<T extends number | string> = {
+  choices: Array<Choice<T>>;
+  selected: T;
+  onSelect: (selected: T) => void;
 };
 
 function isNamedValue<T>(value: any): value is NamedValue<T> {
   return value && typeof value.name === "string" && value.value !== undefined;
 }
 
-export const AutoButtonGroup = <T extends (number | string) | NamedValue<T>>({
+export const AutoButtonGroup = <T extends number | string>({
   choices,
   selected,
   onSelect,
@@ -34,6 +36,7 @@ export const AutoButtonGroup = <T extends (number | string) | NamedValue<T>>({
           onClick={() => {
             onSelect(_value);
           }}
+          sx={{ textTransform: "none" }}
         >
           {name.toString()}
         </Button>

--- a/src/components/CreateCollection.tsx
+++ b/src/components/CreateCollection.tsx
@@ -21,10 +21,10 @@ interface IProps {
 
 const NewCollection = (props: IProps) => {
   const [name, setName] = useState(
-    props.datasetToEdit ? props.datasetToEdit : ""
+    props.datasetToEdit ? props.datasetToEdit : "",
   );
   const [folders, setFolders] = useState(
-    props.datasetToEdit ? props.existingCollections[props.datasetToEdit] : []
+    props.datasetToEdit ? props.existingCollections[props.datasetToEdit] : [],
   );
   const [isErrorOpen, setErrorOpen] = useState(false);
 

--- a/src/components/ImageSlider/ImageSlider.tsx
+++ b/src/components/ImageSlider/ImageSlider.tsx
@@ -11,6 +11,8 @@ interface IProps {
   folders: string[];
   interval: number;
   onStop(): void;
+  sessionLimitEnabled: boolean;
+  sessionImageCount: number;
 }
 
 interface IState {
@@ -49,11 +51,18 @@ export default class ImageSlider extends React.Component<IProps, IState> {
           { files: this.state.files.concat(files), hasLoaded: true },
           () => {
             this.loadRandomImage();
+
+            const sessionLimit = this.props.sessionLimitEnabled
+              ? this.props.sessionImageCount
+              : undefined;
+
             this.timer = new Timer(
               300,
               this.props.interval * 1000,
               this.loadNewImage,
               this.onTick,
+              sessionLimit,
+              this.onSessionComplete
             );
             this.start();
           },
@@ -105,6 +114,12 @@ export default class ImageSlider extends React.Component<IProps, IState> {
 
   stop = () => {
     this.props.onStop();
+  };
+
+  onSessionComplete = () => {
+    console.log("Session limit reached!");
+    // Automatically stop the session when limit is reached
+    this.stop();
   };
 
   render() {

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -7,7 +7,6 @@ import {
   Checkbox,
   FormControlLabel,
   FormGroup,
-  IconButton,
   Input,
 } from "@mui/material";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
@@ -37,17 +36,24 @@ const intervals = [
 export function IntervalSelector(props: IProps) {
   const settings = getSettings();
   const [showImagePath, setShowImagePath] = useState<boolean>(
-    settings.showImagePath
+    settings.showImagePath,
   );
-  const [sessionCount, setSessionCount] = useState(0);
+  const [useSession, setUseSession] = useState<boolean>(false);
+  const [sessionCount, setSessionCount] = useState(10);
 
   const handleChangeImagePath = (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const showImagePath = event.target.checked;
     const settings = getSettings();
     setSettings({ ...settings, showImagePath });
     setShowImagePath(showImagePath);
+  };
+
+  const handleChangeSessionLimit = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setUseSession(event.target.checked);
   };
 
   const handleSessionCountChange = (count: number) => {
@@ -89,7 +95,7 @@ export function IntervalSelector(props: IProps) {
             value={
               props.selected_interval === Infinity
                 ? "-"
-                : props.selected_interval ?? ""
+                : (props.selected_interval ?? "")
             }
             sx={{
               mx: 1,
@@ -100,54 +106,6 @@ export function IntervalSelector(props: IProps) {
             }}
           ></Input>
         </Box>
-      </div>
-      <p>Select Session count</p>
-      <div>
-        <AutoButtonGroup
-          choices={[{ name: "No Limit", value: 0 }, 5, 10, 15, 20, 40]}
-          selected={sessionCount}
-          onSelect={handleSessionCountChange}
-        />
-        <Input
-          size="small"
-          onChange={(e) => {
-            const value = e.target.value || "";
-            if (!value) return handleSessionCountChange(0);
-            const _sessionCount = +value.replace("-", "");
-            !isNaN(_sessionCount) &&
-              _sessionCount > 0 &&
-              handleSessionCountChange(_sessionCount);
-          }}
-          value={sessionCount}
-          sx={{
-            mx: 1,
-            maxWidth: "5rem",
-            input: {
-              textAlign: "center",
-            },
-          }}
-        ></Input>
-        {(() => {
-          const validSession =
-            props.selected_interval != null &&
-            props.selected_interval !== Infinity &&
-            props.selected_interval > 0 &&
-            sessionCount > 0;
-          return (
-            <p
-              style={{
-                color: "gray",
-                visibility: validSession ? "visible" : "hidden",
-              }}
-            >
-              session time: ~
-              {validSession
-                ? Math.ceil((props.selected_interval * sessionCount) / 60)
-                : 0}{" "}
-              min
-            </p>
-          );
-        })()}
       </div>
       <div>
         <Box mb={1}>
@@ -166,6 +124,56 @@ export function IntervalSelector(props: IProps) {
                   }
                   label="Show image path"
                 />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={useSession}
+                      onChange={handleChangeSessionLimit}
+                    />
+                  }
+                  label="Session limit"
+                />
+                {useSession && (
+                  <Box sx={{ marginInline: "20px 0 " }}>
+                    <p style={{ color: "gray" }}>number of images</p>
+                    <AutoButtonGroup
+                      choices={[
+                        { name: "No Limit", value: 0 },
+                        5,
+                        10,
+                        15,
+                        20,
+                        40,
+                      ]}
+                      selected={sessionCount}
+                      onSelect={handleSessionCountChange}
+                    />
+                    <Input
+                      size="small"
+                      onChange={(e) => {
+                        const value = e.target.value || "";
+                        if (!value) return handleSessionCountChange(0);
+                        const _sessionCount = +value.replace("-", "");
+                        !isNaN(_sessionCount) &&
+                          _sessionCount > 0 &&
+                          handleSessionCountChange(_sessionCount);
+                      }}
+                      value={sessionCount}
+                      sx={{
+                        mx: 1,
+                        maxWidth: "5rem",
+                        input: {
+                          textAlign: "center",
+                        },
+                      }}
+                    ></Input>
+                    <p style={{ color: "gray" }}>
+                      session time: ~
+                      {Math.ceil((props.selected_interval * sessionCount) / 60)}{" "}
+                      min
+                    </p>
+                  </Box>
+                )}
               </FormGroup>
             </AccordionDetails>
           </Accordion>
@@ -175,14 +183,7 @@ export function IntervalSelector(props: IProps) {
         <Button
           variant="contained"
           className="wide"
-          onClick={() => {
-            const validSession =
-              props.selected_interval != null &&
-              props.selected_interval !== Infinity &&
-              props.selected_interval > 0 &&
-              sessionCount > 0;
-            props.start(validSession, sessionCount);
-          }}
+          onClick={() => props.start(useSession, sessionCount)}
         >
           Start
         </Button>

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -39,7 +39,7 @@ export function IntervalSelector(props: IProps) {
     settings.showImagePath,
   );
   const [useSession, setUseSession] = useState<boolean>(false);
-  const [sessionCount, setSessionCount] = useState(10);
+  const [sessionCount, setSessionCount] = useState(0);
 
   const handleChangeImagePath = (
     event: React.ChangeEvent<HTMLInputElement>,

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -1,7 +1,9 @@
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
-  ButtonGroup,
   Checkbox,
   FormControlLabel,
   FormGroup,
@@ -9,25 +11,38 @@ import {
   Input,
 } from "@mui/material";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ArrowDropDown from "@mui/icons-material/ArrowDropDown";
 import { useState } from "react";
 import { getSettings, setSettings } from "../utils/localStorage";
+import { AutoButtonGroup } from "./ButtonGroup";
 
 interface IProps {
-  interval?: number;
-  setInterval: (interval: number) => void;
+  selected_interval?: number;
+  onSetInterval: (interval: number) => void;
   onBack: () => void;
   start: () => void;
 }
 
-const intervals = [10, 30, 60, 120, 240, 300];
+const intervals = [
+  { name: "No Interval", value: Infinity },
+  10,
+  30,
+  { name: "1m", value: 60 },
+  { name: "2m", value: 120 },
+  { name: "3m", value: 180 },
+  { name: "4m", value: 240 },
+  { name: "5m", value: 300 },
+];
 
 export function IntervalSelector(props: IProps) {
   const [showImagePath, setShowImagePath] = useState<boolean>(
-    getSettings().showImagePath
+    getSettings().showImagePath,
   );
+  const [useSessionSettings, setUseSessionSettings] = useState<boolean>();
+  const [sessionCount, setSessionCount] = useState(5);
 
   const handleChangeImagePath = (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const showImagePath = event.target.checked;
     const settings = getSettings();
@@ -50,42 +65,24 @@ export function IntervalSelector(props: IProps) {
       </div>
       <div>
         <Box my={1}>
-          <ButtonGroup
-            variant="contained"
-            aria-label="outlined primary button group"
-          >
-            <Button
-              color={props.interval === Infinity ? "info" : undefined}
-              onClick={() => {
-                props.setInterval(Infinity);
-              }}
-            >
-              No Interval
-            </Button>
-
-            {intervals.map((interval) => (
-              <Button
-                key={interval}
-                color={props.interval === interval ? "info" : undefined}
-                onClick={() => {
-                  props.setInterval(interval);
-                }}
-              >
-                {interval}
-              </Button>
-            ))}
-          </ButtonGroup>
+          <AutoButtonGroup
+            choices={intervals}
+            selected={props.selected_interval}
+            onSelect={props.onSetInterval}
+          />
           <Input
             size="small"
-            onChange={(e) =>
-            {
-              const value = e.target.value || '';
-              if(!value) return props.setInterval(Infinity);
-              const interval = +value.replace('-', '');
-              !isNaN(interval) && interval > 0 && props.setInterval(interval)
+            onChange={(e) => {
+              const value = e.target.value || "";
+              if (!value) return props.onSetInterval(Infinity);
+              const interval = +value.replace("-", "");
+              !isNaN(interval) && interval > 0 && props.onSetInterval(interval);
+            }}
+            value={
+              props.selected_interval === Infinity
+                ? "-"
+                : (props.selected_interval ?? "")
             }
-            }
-            value={props.interval === Infinity ? "-" : props.interval ?? ""}
             sx={{
               mx: 1,
               maxWidth: "5rem",
@@ -98,17 +95,72 @@ export function IntervalSelector(props: IProps) {
       </div>
       <div>
         <Box mb={1}>
-          <FormGroup>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={showImagePath}
-                  onChange={handleChangeImagePath}
+          <Accordion>
+            <AccordionSummary expandIcon={<ArrowDropDown />}>
+              extra settings
+            </AccordionSummary>
+            <AccordionDetails sx={{ marginInline: "20px 0" }}>
+              <FormGroup>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={showImagePath}
+                      onChange={handleChangeImagePath}
+                    />
+                  }
+                  label="Show image path"
                 />
-              }
-              label="Show image path"
-            />
-          </FormGroup>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={useSessionSettings}
+                      onChange={() =>
+                        setUseSessionSettings(!useSessionSettings)
+                      }
+                    />
+                  }
+                  label="Session limits"
+                />
+                {useSessionSettings && (
+                  <Box sx={{ marginInline: "20px 0 " }}>
+                    <p style={{ color: "gray" }}>number of images</p>
+                    <AutoButtonGroup
+                      choices={[1, 2, 3, 5, 10, 15, 20, 40]}
+                      selected={sessionCount}
+                      onSelect={(selected) => {
+                        setSessionCount(selected);
+                        console.log(selected);
+                      }}
+                    />
+                    <Input
+                      size="small"
+                      onChange={(e) => {
+                        const value = e.target.value || "";
+                        if (!value) return setSessionCount(0);
+                        const _sessionCount = +value.replace("-", "");
+                        !isNaN(_sessionCount) &&
+                          _sessionCount > 0 &&
+                          setSessionCount(_sessionCount);
+                      }}
+                      value={sessionCount}
+                      sx={{
+                        mx: 1,
+                        maxWidth: "5rem",
+                        input: {
+                          textAlign: "center",
+                        },
+                      }}
+                    ></Input>
+                    <p style={{ color: "gray" }}>
+                      session time: ~
+                      {Math.ceil((props.selected_interval * sessionCount) / 60)}{" "}
+                      min
+                    </p>
+                  </Box>
+                )}
+              </FormGroup>
+            </AccordionDetails>
+          </Accordion>
         </Box>
       </div>
       <div>

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -95,7 +95,7 @@ export function IntervalSelector(props: IProps) {
             value={
               props.selectedInterval === Infinity
                 ? "-"
-                : (propsselectedIntervall ?? "")
+                : (props.selectedInterval ?? "")
             }
             sx={{
               mx: 1,

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -38,7 +38,6 @@ export function IntervalSelector(props: IProps) {
   const [showImagePath, setShowImagePath] = useState<boolean>(
     settings.showImagePath,
   );
-  const [useSession, setUseSession] = useState<boolean>(false);
   const [sessionCount, setSessionCount] = useState(0);
 
   const handleChangeImagePath = (
@@ -48,12 +47,6 @@ export function IntervalSelector(props: IProps) {
     const settings = getSettings();
     setSettings({ ...settings, showImagePath });
     setShowImagePath(showImagePath);
-  };
-
-  const handleChangeSessionLimit = (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    setUseSession(event.target.checked);
   };
 
   const handleSessionCountChange = (count: number) => {
@@ -124,67 +117,56 @@ export function IntervalSelector(props: IProps) {
                   }
                   label="Show image path"
                 />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={useSession}
-                      onChange={handleChangeSessionLimit}
-                    />
-                  }
-                  label="Session limits"
-                />
-                {useSession && (
-                  <Box sx={{ marginInline: "20px 0 " }}>
-                    <p style={{ color: "gray" }}>Number of images</p>
-                    <AutoButtonGroup
-                      choices={[
-                        { name: "No Limit", value: 0 },
-                        { name: "5", value: 5 },
-                        { name: "10", value: 10 },
-                        { name: "15", value: 15 },
-                        { name: "20", value: 20 },
-                        { name: "40", value: 40 },
-                      ]}
-                      selected={sessionCount}
-                      onSelect={handleSessionCountChange}
-                    />
-                    <Input
-                      size="small"
-                      onChange={(e) => {
-                        const value = e.target.value || "";
-                        if (!value) return handleSessionCountChange(0);
-                        const sessionCount = +value.replace("-", "");
-                        !isNaN(sessionCount) &&
-                          sessionCount > 0 &&
-                          handleSessionCountChange(sessionCount);
-                      }}
-                      value={sessionCount}
-                      sx={{
-                        mx: 1,
-                        maxWidth: "5rem",
-                        input: {
-                          textAlign: "center",
-                        },
-                      }}
-                    ></Input>
-                    <p
-                      style={{
-                        color: "gray",
-                        visibility:
-                          props.selectedInterval != null &&
-                          props.selectedInterval !== Infinity &&
-                          props.selectedInterval > 0 &&
-                          sessionCount > 0
-                            ? "visible"
-                            : "hidden",
-                      }}
-                    >
-                      Session time: ~
-                      {Math.ceil((props.selectedInterval * sessionCount) / 60)}{" "}
-                      min
-                    </p>
-                  </Box>
-                )}
+                <Box>
+                  <p style={{ color: "gray" }}>Number of images</p>
+                  <AutoButtonGroup
+                    choices={[
+                      { name: "No Limit", value: 0 },
+                      { name: "5", value: 5 },
+                      { name: "10", value: 10 },
+                      { name: "15", value: 15 },
+                      { name: "20", value: 20 },
+                      { name: "40", value: 40 },
+                    ]}
+                    selected={sessionCount}
+                    onSelect={handleSessionCountChange}
+                  />
+                  <Input
+                    size="small"
+                    onChange={(e) => {
+                      const value = e.target.value || "";
+                      if (!value) return handleSessionCountChange(0);
+                      const sessionCount = +value.replace("-", "");
+                      !isNaN(sessionCount) &&
+                        sessionCount > 0 &&
+                        handleSessionCountChange(sessionCount);
+                    }}
+                    value={sessionCount}
+                    sx={{
+                      mx: 1,
+                      maxWidth: "5rem",
+                      input: {
+                        textAlign: "center",
+                      },
+                    }}
+                  ></Input>
+                  <p
+                    style={{
+                      color: "gray",
+                      visibility:
+                        props.selectedInterval != null &&
+                        props.selectedInterval !== Infinity &&
+                        props.selectedInterval > 0 &&
+                        sessionCount > 0
+                          ? "visible"
+                          : "hidden",
+                    }}
+                  >
+                    Session time: ~
+                    {Math.ceil((props.selectedInterval * sessionCount) / 60)}{" "}
+                    min
+                  </p>
+                </Box>
               </FormGroup>
             </AccordionDetails>
           </Accordion>
@@ -194,7 +176,7 @@ export function IntervalSelector(props: IProps) {
         <Button
           variant="contained"
           className="wide"
-          onClick={() => props.start(useSession, sessionCount)}
+          onClick={() => props.start(true, sessionCount)}
         >
           Start
         </Button>

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -37,17 +37,14 @@ const intervals = [
 export function IntervalSelector(props: IProps) {
   const settings = getSettings();
   const [showImagePath, setShowImagePath] = useState<boolean>(
-    settings.showImagePath,
-  );
-  const [useSessionSettings, setUseSessionSettings] = useState<boolean>(
-    settings.sessionLimitEnabled ?? false,
+    settings.showImagePath
   );
   const [sessionCount, setSessionCount] = useState(
-    settings.sessionImageCount ?? 10,
+    settings.sessionImageCount ?? 10
   );
 
   const handleChangeImagePath = (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: React.ChangeEvent<HTMLInputElement>
   ) => {
     const showImagePath = event.target.checked;
     const settings = getSettings();
@@ -56,12 +53,11 @@ export function IntervalSelector(props: IProps) {
   };
 
   const handleChangeSessionLimit = (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: React.ChangeEvent<HTMLInputElement>
   ) => {
     const sessionLimitEnabled = event.target.checked;
     const settings = getSettings();
     setSettings({ ...settings, sessionLimitEnabled });
-    setUseSessionSettings(sessionLimitEnabled);
   };
 
   const handleSessionCountChange = (count: number) => {
@@ -78,11 +74,15 @@ export function IntervalSelector(props: IProps) {
           alignItems: "center",
         }}
       >
-        <IconButton onClick={props.onBack} aria-label="back">
-          <ChevronLeftIcon />
-        </IconButton>
-        Select Interval
+        <Button
+          startIcon={<ChevronLeftIcon />}
+          onClick={props.onBack}
+          aria-label="back"
+        >
+          back
+        </Button>
       </div>
+      <p>Select Interval</p>
       <div>
         <Box my={1}>
           <AutoButtonGroup
@@ -101,7 +101,7 @@ export function IntervalSelector(props: IProps) {
             value={
               props.selected_interval === Infinity
                 ? "-"
-                : (props.selected_interval ?? "")
+                : props.selected_interval ?? ""
             }
             sx={{
               mx: 1,
@@ -113,9 +113,57 @@ export function IntervalSelector(props: IProps) {
           ></Input>
         </Box>
       </div>
+      <p>Select Session count</p>
+      <div>
+        <AutoButtonGroup
+          choices={[{ name: "No Limit", value: 0 }, 5, 10, 15, 20, 40]}
+          selected={sessionCount}
+          onSelect={handleSessionCountChange}
+        />
+        <Input
+          size="small"
+          onChange={(e) => {
+            const value = e.target.value || "";
+            if (!value) return handleSessionCountChange(0);
+            const _sessionCount = +value.replace("-", "");
+            !isNaN(_sessionCount) &&
+              _sessionCount > 0 &&
+              handleSessionCountChange(_sessionCount);
+          }}
+          value={sessionCount}
+          sx={{
+            mx: 1,
+            maxWidth: "5rem",
+            input: {
+              textAlign: "center",
+            },
+          }}
+        ></Input>
+        {(() => {
+          const validSession =
+            props.selected_interval != null &&
+            props.selected_interval !== Infinity &&
+            props.selected_interval > 0 &&
+            sessionCount > 0;
+          return (
+            <p
+              style={{
+                color: "gray",
+                visibility: validSession ? "visible" : "hidden",
+              }}
+            >
+              session time: ~
+              {validSession
+                ? Math.ceil((props.selected_interval * sessionCount) / 60)
+                : 0}{" "}
+              min
+            </p>
+          );
+        })()}
+      </div>
       <div>
         <Box mb={1}>
-          <Accordion>
+          <Accordion elevation={0} disableGutters>
             <AccordionSummary expandIcon={<ArrowDropDown />}>
               extra settings
             </AccordionSummary>
@@ -130,56 +178,6 @@ export function IntervalSelector(props: IProps) {
                   }
                   label="Show image path"
                 />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={useSessionSettings}
-                      onChange={handleChangeSessionLimit}
-                    />
-                  }
-                  label="Session limits"
-                />
-                {useSessionSettings && (
-                  <Box sx={{ marginInline: "20px 0 " }}>
-                    <p style={{ color: "gray" }}>number of images</p>
-                    <AutoButtonGroup
-                      choices={[
-                        { name: "No Limit", value: 0 },
-                        5,
-                        10,
-                        15,
-                        20,
-                        40,
-                      ]}
-                      selected={sessionCount}
-                      onSelect={handleSessionCountChange}
-                    />
-                    <Input
-                      size="small"
-                      onChange={(e) => {
-                        const value = e.target.value || "";
-                        if (!value) return handleSessionCountChange(0);
-                        const _sessionCount = +value.replace("-", "");
-                        !isNaN(_sessionCount) &&
-                          _sessionCount > 0 &&
-                          handleSessionCountChange(_sessionCount);
-                      }}
-                      value={sessionCount}
-                      sx={{
-                        mx: 1,
-                        maxWidth: "5rem",
-                        input: {
-                          textAlign: "center",
-                        },
-                      }}
-                    ></Input>
-                    <p style={{ color: "gray" }}>
-                      session time: ~
-                      {Math.ceil((props.selected_interval * sessionCount) / 60)}{" "}
-                      min
-                    </p>
-                  </Box>
-                )}
               </FormGroup>
             </AccordionDetails>
           </Accordion>
@@ -189,7 +187,14 @@ export function IntervalSelector(props: IProps) {
         <Button
           variant="contained"
           className="wide"
-          onClick={() => props.start(useSessionSettings, sessionCount)}
+          onClick={() => {
+            const validSession =
+              props.selected_interval != null &&
+              props.selected_interval !== Infinity &&
+              props.selected_interval > 0 &&
+              sessionCount > 0;
+            props.start(validSession, sessionCount);
+          }}
         >
           Start
         </Button>

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -16,7 +16,7 @@ import { getSettings, setSettings } from "../utils/localStorage";
 import { AutoButtonGroup } from "./ButtonGroup";
 
 interface IProps {
-  selected_interval?: number;
+  selectedInterval?: number;
   onSetInterval: (interval: number) => void;
   onBack: () => void;
   start: (sessionLimitEnabled: boolean, sessionImageCount: number) => void;
@@ -81,7 +81,7 @@ export function IntervalSelector(props: IProps) {
         <Box my={1}>
           <AutoButtonGroup
             choices={intervals}
-            selected={props.selected_interval}
+            selected={props.selectedInterval}
             onSelect={props.onSetInterval}
           />
           <Input
@@ -93,9 +93,9 @@ export function IntervalSelector(props: IProps) {
               !isNaN(interval) && interval > 0 && props.onSetInterval(interval);
             }}
             value={
-              props.selected_interval === Infinity
+              props.selectedInterval === Infinity
                 ? "-"
-                : (props.selected_interval ?? "")
+                : (propsselectedIntervall ?? "")
             }
             sx={{
               mx: 1,
@@ -111,7 +111,7 @@ export function IntervalSelector(props: IProps) {
         <Box mb={1}>
           <Accordion>
             <AccordionSummary expandIcon={<ArrowDropDown />}>
-              extra settings
+              Additional settings
             </AccordionSummary>
             <AccordionDetails sx={{ marginInline: "20px 0" }}>
               <FormGroup>
@@ -131,11 +131,11 @@ export function IntervalSelector(props: IProps) {
                       onChange={handleChangeSessionLimit}
                     />
                   }
-                  label="Session limit"
+                  label="Session limits"
                 />
                 {useSession && (
                   <Box sx={{ marginInline: "20px 0 " }}>
-                    <p style={{ color: "gray" }}>number of images</p>
+                    <p style={{ color: "gray" }}>Number of images</p>
                     <AutoButtonGroup
                       choices={[
                         { name: "No Limit", value: 0 },
@@ -153,10 +153,10 @@ export function IntervalSelector(props: IProps) {
                       onChange={(e) => {
                         const value = e.target.value || "";
                         if (!value) return handleSessionCountChange(0);
-                        const _sessionCount = +value.replace("-", "");
-                        !isNaN(_sessionCount) &&
-                          _sessionCount > 0 &&
-                          handleSessionCountChange(_sessionCount);
+                        const sessionCount = +value.replace("-", "");
+                        !isNaN(sessionCount) &&
+                          sessionCount > 0 &&
+                          handleSessionCountChange(sessionCount);
                       }}
                       value={sessionCount}
                       sx={{
@@ -167,9 +167,20 @@ export function IntervalSelector(props: IProps) {
                         },
                       }}
                     ></Input>
-                    <p style={{ color: "gray" }}>
-                      session time: ~
-                      {Math.ceil((props.selected_interval * sessionCount) / 60)}{" "}
+                    <p
+                      style={{
+                        color: "gray",
+                        visibility:
+                          props.selectedInterval != null &&
+                          props.selectedInterval !== Infinity &&
+                          props.selectedInterval > 0 &&
+                          sessionCount > 0
+                            ? "visible"
+                            : "hidden",
+                      }}
+                    >
+                      Session time: ~
+                      {Math.ceil((props.selectedInterval * sessionCount) / 60)}{" "}
                       min
                     </p>
                   </Box>

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -143,7 +143,14 @@ export function IntervalSelector(props: IProps) {
                   <Box sx={{ marginInline: "20px 0 " }}>
                     <p style={{ color: "gray" }}>number of images</p>
                     <AutoButtonGroup
-                      choices={[1, 2, 3, 5, 10, 15, 20, 40]}
+                      choices={[
+                        { name: "No Limit", value: 0 },
+                        5,
+                        10,
+                        15,
+                        20,
+                        40,
+                      ]}
                       selected={sessionCount}
                       onSelect={handleSessionCountChange}
                     />

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -39,9 +39,7 @@ export function IntervalSelector(props: IProps) {
   const [showImagePath, setShowImagePath] = useState<boolean>(
     settings.showImagePath
   );
-  const [sessionCount, setSessionCount] = useState(
-    settings.sessionImageCount ?? 10
-  );
+  const [sessionCount, setSessionCount] = useState(0);
 
   const handleChangeImagePath = (
     event: React.ChangeEvent<HTMLInputElement>
@@ -52,17 +50,7 @@ export function IntervalSelector(props: IProps) {
     setShowImagePath(showImagePath);
   };
 
-  const handleChangeSessionLimit = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const sessionLimitEnabled = event.target.checked;
-    const settings = getSettings();
-    setSettings({ ...settings, sessionLimitEnabled });
-  };
-
   const handleSessionCountChange = (count: number) => {
-    const settings = getSettings();
-    setSettings({ ...settings, sessionImageCount: count });
     setSessionCount(count);
   };
 
@@ -163,7 +151,7 @@ export function IntervalSelector(props: IProps) {
       </div>
       <div>
         <Box mb={1}>
-          <Accordion elevation={0} disableGutters>
+          <Accordion>
             <AccordionSummary expandIcon={<ArrowDropDown />}>
               extra settings
             </AccordionSummary>

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -20,7 +20,7 @@ interface IProps {
   selected_interval?: number;
   onSetInterval: (interval: number) => void;
   onBack: () => void;
-  start: () => void;
+  start: (sessionLimitEnabled: boolean, sessionImageCount: number) => void;
 }
 
 const intervals = [
@@ -35,11 +35,16 @@ const intervals = [
 ];
 
 export function IntervalSelector(props: IProps) {
+  const settings = getSettings();
   const [showImagePath, setShowImagePath] = useState<boolean>(
-    getSettings().showImagePath,
+    settings.showImagePath,
   );
-  const [useSessionSettings, setUseSessionSettings] = useState<boolean>();
-  const [sessionCount, setSessionCount] = useState(5);
+  const [useSessionSettings, setUseSessionSettings] = useState<boolean>(
+    settings.sessionLimitEnabled ?? false,
+  );
+  const [sessionCount, setSessionCount] = useState(
+    settings.sessionImageCount ?? 10,
+  );
 
   const handleChangeImagePath = (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -48,6 +53,21 @@ export function IntervalSelector(props: IProps) {
     const settings = getSettings();
     setSettings({ ...settings, showImagePath });
     setShowImagePath(showImagePath);
+  };
+
+  const handleChangeSessionLimit = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const sessionLimitEnabled = event.target.checked;
+    const settings = getSettings();
+    setSettings({ ...settings, sessionLimitEnabled });
+    setUseSessionSettings(sessionLimitEnabled);
+  };
+
+  const handleSessionCountChange = (count: number) => {
+    const settings = getSettings();
+    setSettings({ ...settings, sessionImageCount: count });
+    setSessionCount(count);
   };
 
   return (
@@ -114,9 +134,7 @@ export function IntervalSelector(props: IProps) {
                   control={
                     <Checkbox
                       checked={useSessionSettings}
-                      onChange={() =>
-                        setUseSessionSettings(!useSessionSettings)
-                      }
+                      onChange={handleChangeSessionLimit}
                     />
                   }
                   label="Session limits"
@@ -127,20 +145,17 @@ export function IntervalSelector(props: IProps) {
                     <AutoButtonGroup
                       choices={[1, 2, 3, 5, 10, 15, 20, 40]}
                       selected={sessionCount}
-                      onSelect={(selected) => {
-                        setSessionCount(selected);
-                        console.log(selected);
-                      }}
+                      onSelect={handleSessionCountChange}
                     />
                     <Input
                       size="small"
                       onChange={(e) => {
                         const value = e.target.value || "";
-                        if (!value) return setSessionCount(0);
+                        if (!value) return handleSessionCountChange(0);
                         const _sessionCount = +value.replace("-", "");
                         !isNaN(_sessionCount) &&
                           _sessionCount > 0 &&
-                          setSessionCount(_sessionCount);
+                          handleSessionCountChange(_sessionCount);
                       }}
                       value={sessionCount}
                       sx={{
@@ -164,7 +179,11 @@ export function IntervalSelector(props: IProps) {
         </Box>
       </div>
       <div>
-        <Button variant="contained" className="wide" onClick={props.start}>
+        <Button
+          variant="contained"
+          className="wide"
+          onClick={() => props.start(useSessionSettings, sessionCount)}
+        >
           Start
         </Button>
       </div>

--- a/src/components/IntervalSelector.tsx
+++ b/src/components/IntervalSelector.tsx
@@ -24,8 +24,8 @@ interface IProps {
 
 const intervals = [
   { name: "No Interval", value: Infinity },
-  10,
-  30,
+  { name: "10s", value: 10 },
+  { name: "30s", value: 30 },
   { name: "1m", value: 60 },
   { name: "2m", value: 120 },
   { name: "3m", value: 180 },
@@ -139,11 +139,11 @@ export function IntervalSelector(props: IProps) {
                     <AutoButtonGroup
                       choices={[
                         { name: "No Limit", value: 0 },
-                        5,
-                        10,
-                        15,
-                        20,
-                        40,
+                        { name: "5", value: 5 },
+                        { name: "10", value: 10 },
+                        { name: "15", value: 15 },
+                        { name: "20", value: 20 },
+                        { name: "40", value: 40 },
                       ]}
                       selected={sessionCount}
                       onSelect={handleSessionCountChange}

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -19,7 +19,7 @@ interface IProps {
     filepaths: string[],
     interval: number,
     sessionLimitEnabled: boolean,
-    sessionImageCount: number
+    sessionImageCount: number,
   ): void;
 }
 
@@ -98,7 +98,7 @@ export default class MainMenu extends React.Component<IProps, IState> {
       this.state.folders,
       this.state.interval,
       sessionLimitEnabled,
-      sessionImageCount
+      sessionImageCount,
     );
   };
 
@@ -209,7 +209,7 @@ export default class MainMenu extends React.Component<IProps, IState> {
             {this.state.folders?.length && !showDatasetForm && (
               <IntervalSelector
                 onBack={this.clearFolders}
-                selected_interval={this.state.interval}
+                selectedInterval={this.state.interval}
                 onSetInterval={this.setInterval}
                 start={this.start}
               />

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -150,17 +150,17 @@ export default class MainMenu extends React.Component<IProps, IState> {
                               this.setState({ datasetToEdit: datasetKey })
                             }
                           >
-                            <EditIcon  fontSize="small"/>
+                            <EditIcon fontSize="small" />
                           </IconButton>
                           <IconButton
                             aria-label="delete"
                             onClick={() => this.removeDataSet(datasetKey)}
                             size="small"
                           >
-                            <DeleteIcon fontSize="small"/>
+                            <DeleteIcon fontSize="small" />
                           </IconButton>
                         </ListItem>
-                      )
+                      ),
                     )}
                   </List>
                 </div>
@@ -195,8 +195,8 @@ export default class MainMenu extends React.Component<IProps, IState> {
             {this.state.folders?.length && !showDatasetForm && (
               <IntervalSelector
                 onBack={this.clearFolders}
-                interval={this.state.interval}
-                setInterval={this.setInterval}
+                selected_interval={this.state.interval}
+                onSetInterval={this.setInterval}
                 start={this.start}
               />
             )}

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -15,7 +15,12 @@ import { Header } from "./Header";
 import { IntervalSelector } from "./IntervalSelector";
 
 interface IProps {
-  onDirSelected(filepaths: string[], interval: number): void;
+  onDirSelected(
+    filepaths: string[],
+    interval: number,
+    sessionLimitEnabled: boolean,
+    sessionImageCount: number
+  ): void;
 }
 
 interface IState {
@@ -24,6 +29,8 @@ interface IState {
   datasets: Record<string, string[]>;
   showDatasetCreation: boolean;
   datasetToEdit?: string;
+  sessionLimitEnabled: boolean;
+  sessionImageCount: number;
 }
 
 export default class MainMenu extends React.Component<IProps, IState> {
@@ -38,6 +45,8 @@ export default class MainMenu extends React.Component<IProps, IState> {
       interval: Infinity,
       datasets,
       showDatasetCreation: false,
+      sessionLimitEnabled: false,
+      sessionImageCount: 5,
     };
   }
 
@@ -84,8 +93,13 @@ export default class MainMenu extends React.Component<IProps, IState> {
     this.setState({ interval });
   };
 
-  start = () => {
-    this.props.onDirSelected(this.state.folders, this.state.interval);
+  start = (sessionLimitEnabled: boolean, sessionImageCount: number) => {
+    this.props.onDirSelected(
+      this.state.folders,
+      this.state.interval,
+      sessionLimitEnabled,
+      sessionImageCount
+    );
   };
 
   clearFolders = () => {

--- a/src/main.container.tsx
+++ b/src/main.container.tsx
@@ -1,13 +1,15 @@
 import React from "react";
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider, createTheme } from "@mui/material/styles";
 import MainMenu from "./components/MainMenu";
 import ImageSlider from "./components/ImageSlider/ImageSlider";
 
 interface IProps { }
 
 interface IState {
-  selectedFolders: string[],
-  interval?: number
+  selectedFolders: string[];
+  interval?: number;
+  sessionLimitEnabled: boolean;
+  sessionImageCount: number;
 }
 
 const darkTheme = createTheme({
@@ -21,25 +23,43 @@ export default class Main extends React.Component<IProps, IState> {
     super(props);
     this.state = {
       selectedFolders: null,
-      interval: null
+      interval: null,
+      sessionLimitEnabled: false,
+      sessionImageCount: 5,
     };
   }
 
-  onDirselected = (dirs: string[], interval: number) => { this.setState({ selectedFolders: dirs, interval }) }
+  onDirselected = (
+    dirs: string[],
+    interval: number,
+    sessionLimitEnabled: boolean,
+    sessionImageCount: number
+  ) => {
+    this.setState({
+      selectedFolders: dirs,
+      interval,
+      sessionLimitEnabled,
+      sessionImageCount,
+    });
+  };
 
   returnToMainMenu = () => this.setState({ selectedFolders: null })
 
   render(): any {
-  return(
-    <ThemeProvider theme={darkTheme}>
-      {this.state.selectedFolders?.length
-        ? (<ImageSlider
+    return (
+      <ThemeProvider theme={darkTheme}>
+        {this.state.selectedFolders?.length ? (
+          <ImageSlider
             folders={this.state.selectedFolders}
             onStop={this.returnToMainMenu}
-            interval={this.state.interval} />)
-        : (<MainMenu 
-            onDirSelected={this.onDirselected} />)
-      }
-    </ThemeProvider>
-  )}
+            interval={this.state.interval}
+            sessionLimitEnabled={this.state.sessionLimitEnabled}
+            sessionImageCount={this.state.sessionImageCount}
+          />
+        ) : (
+          <MainMenu onDirSelected={this.onDirselected} />
+        )}
+      </ThemeProvider>
+    );
+  }
 }

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,7 +1,5 @@
 interface ISettings {
   showImagePath?: boolean;
-  sessionLimitEnabled?: boolean;
-  sessionImageCount?: number;
 }
 
 export const getSettings = (): ISettings => {

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,5 +1,7 @@
 interface ISettings {
   showImagePath?: boolean;
+  sessionLimitEnabled?: boolean;
+  sessionImageCount?: number;
 }
 
 export const getSettings = (): ISettings => {


### PR DESCRIPTION
we did a 2 hour session using this app 2 days ago, it works great! 🙌 . But we used an external timer to keep track of time per session type, the way we happen to do our sessions is to aim for 20 minutes of drawing with a 10 minute break, each time, stepping up the time spent (so at first we get several drawings at a shorter time, and it serves as a warmup).

<img width="596" height="510" alt="image" src="https://github.com/user-attachments/assets/d175292c-1f3d-4ccf-9f41-133ba09a9483" />


Thinking behind this feature was to have the app take care of some of this timekeeping for us.

- added a nice utility component AutoButtonGroup (possibly premature, but used twice now)
- changed the display of the interals to use `M` suffix on minutes (the values beneath are still the same), this is less mathsy overhead once you get into the hundreds of seconds.
- grouped session limit + the existing show file paths feature under `extra settings` on the interval selection menu and hide them under an Accordion in the session (most people probably don't want to touch them on the "code happy path")
- rudimentary display of estimated session time in total (resolution in whole minutes)
- should also be stored in the settings (along with other settings)